### PR TITLE
Rename `quarkus-sqlite4j` to `quarkus-jdbc-sqlite4j`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
-[![Build](https://github.com/quarkiverse/quarkus-sqlite4j/workflows/Build/badge.svg)](https://github.com/quarkiverse/quarkus-sqlite4j/actions?query=workflow%3ABuild)
-[![Maven Central](https://img.shields.io/maven-central/v/io.quarkiverse.jdbc/quarkus-sqlite4j.svg?label=Maven%20Central&style=flat-square)](https://search.maven.org/artifact/io.quarkiverse.jdbc/quarkus-sqlite4j)
+[![Build](https://github.com/quarkiverse/quarkus-jdbc-sqlite4j/workflows/Build/badge.svg)](https://github.com/quarkiverse/quarkus-jdbc-sqlite4j/actions?query=workflow%3ABuild)
+[![Maven Central](https://img.shields.io/maven-central/v/io.quarkiverse.jdbc/quarkus-jdbc-sqlite4j.svg?label=Maven%20Central&style=flat-square)](https://search.maven.org/artifact/io.quarkiverse.jdbc/quarkus-jdbc-sqlite4j)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 
 Quarkus SQLite4j is a Quarkus extension for the SQLite Embedded database.
@@ -13,8 +13,8 @@ This project has been forked from the original [quarkus-jdbc-sqlite](https://git
 The key difference is in how SQLite is bundled/executed:
 
 - `quarkus-jdbc-sqlite` builds on top of the stable [xerial/sqlite-jdbc](https://github.com/xerial/sqlite-jdbc/) driver that bundle several builds of SQLite for a lot of different architectures and uses JNI to access the functionality
-- `quarkus-sqlite4j` builds on top of the fork [roastedroot/sqlite4j](https://github.com/roastedroot/sqlite4j) which instead compiles SQLite to pure Java bytecode thanks to [Chicory](https://github.com/dylibso/chicory) and directly interacts with it
+- `quarkus-jdbc-sqlite4j` builds on top of the fork [roastedroot/sqlite4j](https://github.com/roastedroot/sqlite4j) which instead compiles SQLite to pure Java bytecode thanks to [Chicory](https://github.com/dylibso/chicory) and directly interacts with it
 
 ## User Documentation
 
-https://docs.quarkiverse.io/quarkus-sqlite4j/dev/index.html
+https://docs.quarkiverse.io/quarkus-jdbc-sqlite4j/dev/index.html

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -3,10 +3,10 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jdbc</groupId>
-    <artifactId>quarkus-sqlite4j-parent</artifactId>
+    <artifactId>quarkus-jdbc-sqlite4j-parent</artifactId>
     <version>999-SNAPSHOT</version>
   </parent>
-  <artifactId>quarkus-sqlite4j-deployment</artifactId>
+  <artifactId>quarkus-jdbc-sqlite4j-deployment</artifactId>
   <name>Quarkus - SQLite4j - Deployment</name>
   <dependencies>
     <dependency>
@@ -27,7 +27,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.jdbc</groupId>
-      <artifactId>quarkus-sqlite4j</artifactId>
+      <artifactId>quarkus-jdbc-sqlite4j</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/deployment/src/main/java/io/quarkiverse/sqlite4j/deployment/JDBCSqliteProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/sqlite4j/deployment/JDBCSqliteProcessor.java
@@ -24,7 +24,7 @@ import io.roastedroot.sqlite4j.SQLiteDataSource;
 @SuppressWarnings("unused")
 class JDBCSqliteProcessor {
 
-    private static final String FEATURE = "sqlite4j";
+    private static final String FEATURE = "jdbc-sqlite4j";
 
     static final String DRIVER_NAME = JDBC.class.getName();
     private static final String DATA_SOURCE_NAME = SQLiteDataSource.class.getName();

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -3,19 +3,19 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jdbc</groupId>
-    <artifactId>quarkus-sqlite4j-parent</artifactId>
+    <artifactId>quarkus-jdbc-sqlite4j-parent</artifactId>
     <version>999-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>quarkus-sqlite4j-docs</artifactId>
+  <artifactId>quarkus-jdbc-sqlite4j-docs</artifactId>
   <name>Quarkus - SQLite4j - Documentation</name>
 
   <dependencies>
     <!-- Make sure the doc is built after the other artifacts -->
     <dependency>
       <groupId>io.quarkiverse.jdbc</groupId>
-      <artifactId>quarkus-sqlite4j-deployment</artifactId>
+      <artifactId>quarkus-jdbc-sqlite4j-deployment</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jdbc</groupId>
-    <artifactId>quarkus-sqlite4j-parent</artifactId>
+    <artifactId>quarkus-jdbc-sqlite4j-parent</artifactId>
     <version>999-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-sqlite4j-integration-tests</artifactId>
@@ -15,7 +15,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.jdbc</groupId>
-      <artifactId>quarkus-sqlite4j</artifactId>
+      <artifactId>quarkus-jdbc-sqlite4j</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>18</version>
   </parent>
   <groupId>io.quarkiverse.jdbc</groupId>
-  <artifactId>quarkus-sqlite4j-parent</artifactId>
+  <artifactId>quarkus-jdbc-sqlite4j-parent</artifactId>
   <version>999-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Quarkus - SQLite4j - Parent</name>
@@ -16,9 +16,9 @@
     <module>runtime</module>
   </modules>
   <scm>
-    <connection>scm:git:git@github.com:quarkiverse/quarkus-sqlite4j.git</connection>
-    <developerConnection>scm:git:git@github.com:quarkiverse/quarkus-sqlite4j.git</developerConnection>
-    <url>https://github.com/quarkiverse/quarkus-sqlite4j</url>
+    <connection>scm:git:git@github.com:quarkiverse/quarkus-jdbc-sqlite4j.git</connection>
+    <developerConnection>scm:git:git@github.com:quarkiverse/quarkus-jdbc-sqlite4j.git</developerConnection>
+    <url>https://github.com/quarkiverse/quarkus-jdbc-sqlite4j</url>
     <tag>HEAD</tag>
   </scm>
   <properties>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -3,10 +3,10 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.jdbc</groupId>
-    <artifactId>quarkus-sqlite4j-parent</artifactId>
+    <artifactId>quarkus-jdbc-sqlite4j-parent</artifactId>
     <version>999-SNAPSHOT</version>
   </parent>
-  <artifactId>quarkus-sqlite4j</artifactId>
+  <artifactId>quarkus-jdbc-sqlite4j</artifactId>
   <name>Quarkus - SQLite4j - Runtime</name>
   <description>Connect to the SQLite database via JDBC</description>
   <dependencies>


### PR DESCRIPTION
To be consistent with the other JDBC extensions
